### PR TITLE
README file and better binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INCLUDE	:= include
 LIB		:= lib
 
 ifeq ($(OS),Windows_NT)
-MAIN	:= main.exe
+MAIN	:= loopadrome.exe
 SOURCEDIRS	:= $(SRC)
 INCLUDEDIRS	:= $(INCLUDE)
 LIBDIRS		:= $(LIB)
@@ -35,7 +35,7 @@ FIXPATH = $(subst /,\,$1)
 RM			:= del /q /f
 MD	:= mkdir
 else
-MAIN	:= main
+MAIN	:= loopadrome
 SOURCEDIRS	:= $(shell find $(SRC) -type d)
 INCLUDEDIRS	:= $(shell find $(INCLUDE) -type d)
 LIBDIRS		:= $(shell find $(LIB) -type d)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ♾️ Loopadrome
+
+A looper in C, using [ECS](https://en.wikipedia.org/wiki/Entity_component_system).
+
+## Usage
+
+### For MacOS and Linux
+
+```shell
+make
+./output/loopadrome
+```
+
+### For Windows
+
+```shell
+make
+./output/loopadrome.exe
+```
+
+... or something. I don't have a Windows machine to test on 😰. 


### PR DESCRIPTION
- Adding a simple README file with simple instructions. Don't know if works on WIndows thought.
- A better binary name. Instead of 'main' now using 'loopadrome' or 'loopadrome.exe' - but must insist that every windows change is untested 😰.