### PR TITLE
fix: better handling mapping a bool to a bool* for the window_fullscr…

### DIFF
--- a/src/game/window/win_entity.c
+++ b/src/game/window/win_entity.c
@@ -18,7 +18,10 @@ void win_create_entity (
 
     ecs_component* window_size_component = ecs_create_component(WINDOW_SIZE_COMPONENT, size);
     ecs_component* window_title_component = ecs_create_component(WINDOW_TITLE_COMPONENT, title);
-    ecs_component* window_fullscreen_component = ecs_create_component(WINDOW_FULLSCREEN_COMPONENT, &is_fullscreen);
+    
+    bool* is_fullscreen_ptr = malloc(sizeof(bool));
+    *is_fullscreen_ptr = is_fullscreen;
+    ecs_component* window_fullscreen_component = ecs_create_component(WINDOW_FULLSCREEN_COMPONENT, is_fullscreen_ptr);
 
     GLFWwindow* window = NULL;
 

--- a/src/game/window/win_system.c
+++ b/src/game/window/win_system.c
@@ -78,7 +78,7 @@ void _win_start_system (eng_context* ctx) {
 }
 
 void _win_update_system (eng_context* ctx, float delta_time) {
-
+    
     ecs_entity* window_entity = eng_find_entity(ctx, WINDOW_ENTITY);
 
     if (window_entity == NULL) {
@@ -101,13 +101,13 @@ void _win_update_system (eng_context* ctx, float delta_time) {
     char title_prefix[11];
     strncpy(title_prefix, title, 11);
     title_prefix[11] = '\0';
-    char* new_title[15];
+    char new_title[30];
     sprintf(new_title, "%s%d", title_prefix, title_index);
     win_title_comp->data = new_title;
 
     ecs_component* win_fullscreen_comp = eng_find_component(window_entity, WINDOW_FULLSCREEN_COMPONENT);
 
-    int is_fullscreen = *((int*) win_fullscreen_comp->data);
+    bool is_fullscreen = *((bool*) win_fullscreen_comp->data);
 
     ecs_component* win_instance_comp = eng_find_component(window_entity, WINDOW_INSTANCE_COMPONENT);
 

--- a/src/game/window/win_system.c
+++ b/src/game/window/win_system.c
@@ -78,7 +78,7 @@ void _win_start_system (eng_context* ctx) {
 }
 
 void _win_update_system (eng_context* ctx, float delta_time) {
-    
+
     ecs_entity* window_entity = eng_find_entity(ctx, WINDOW_ENTITY);
 
     if (window_entity == NULL) {


### PR DESCRIPTION
…een_component; increasing the title buffer to avoid a warning and using the buffer value instead of its pointer